### PR TITLE
Centralize plugin name + version into tealium.dart after init

### DIFF
--- a/android/src/main/kotlin/com/tealium/Constants.kt
+++ b/android/src/main/kotlin/com/tealium/Constants.kt
@@ -3,8 +3,6 @@
 package com.tealium
 
 const val INSTANCE_NAME: String = "main"
-const val PLUGIN_NAME: String = "Tealium-Flutter"
-const val PLUGIN_VERSION: String = "2.0.0"
 
 const val KEY_CONFIG_ACCOUNT: String = "account"
 const val KEY_CONFIG_PROFILE: String = "profile"

--- a/android/src/main/kotlin/com/tealium/TealiumPlugin.kt
+++ b/android/src/main/kotlin/com/tealium/TealiumPlugin.kt
@@ -70,8 +70,6 @@ class TealiumPlugin : FlutterPlugin, MethodCallHandler {
 
             tealium = Tealium.create(INSTANCE_NAME, config) {
                 Log.d(BuildConfig.TAG, "Instance Initialized")
-                dataLayer.putString("plugin_name", PLUGIN_NAME, Expiry.FOREVER)
-                dataLayer.putString("plugin_version", PLUGIN_VERSION, Expiry.FOREVER)
                 events.subscribe(EmitterListeners(channel))
                 result.onMain().success(true)
             }

--- a/ios/Classes/SwiftTealiumPlugin.swift
+++ b/ios/Classes/SwiftTealiumPlugin.swift
@@ -63,7 +63,7 @@ public class SwiftTealiumPlugin: NSObject, FlutterPlugin {
             return result(false)
         }
         self.config = localConfig.copy
-        tealium = Tealium(config: localConfig) { [weak self] _ in
+        tealium = Tealium(config: localConfig) { _ in
             result(true)
         }
   }

--- a/ios/Classes/SwiftTealiumPlugin.swift
+++ b/ios/Classes/SwiftTealiumPlugin.swift
@@ -63,10 +63,7 @@ public class SwiftTealiumPlugin: NSObject, FlutterPlugin {
             return result(false)
         }
         self.config = localConfig.copy
-        tealium = Tealium(config: localConfig) { [weak self] _ in 
-            self?.tealium?.dataLayer.add(data: ["plugin_name": TealiumFlutterConstants.pluginName,
-             "plugin_version": TealiumFlutterConstants.pluginVersion],
-              expiry: .forever)
+        tealium = Tealium(config: localConfig) { [weak self] _ in
             result(true)
         }
   }

--- a/ios/Classes/TealiumFlutterConstants.swift
+++ b/ios/Classes/TealiumFlutterConstants.swift
@@ -1,7 +1,4 @@
 public enum TealiumFlutterConstants {
-
-    static let pluginName = "Tealium-Flutter"
-    static let pluginVersion = "2.0.0"
     
     static let tagManagement = "TagManagement"
     static let collect = "Collect"

--- a/lib/tealium.dart
+++ b/lib/tealium.dart
@@ -6,6 +6,8 @@ import 'common.dart';
 import 'events/event_emitter.dart';
 
 class Tealium {
+  static const String plugin_name= 'Tealium-Flutter';
+  static const String plugin_version = '2.0.0';
   static const MethodChannel _channel = const MethodChannel('tealium');
   static EventEmitter emitter = new EventEmitter();
   static Map<String, Function> _remoteCommands = new Map();
@@ -20,7 +22,7 @@ class Tealium {
         .contains(Dispatchers.RemoteCommands.toString())) {
       _handleListener(EventListenerNames.remoteCommand);
     }
-    return await _channel.invokeMethod('initialize', {
+    var initialized = await _channel.invokeMethod('initialize', {
       'account': config.account,
       'profile': config.profile,
       'environment': config.environment,
@@ -45,6 +47,14 @@ class Tealium {
       'useRemoteLibrarySettings': config.useRemoteLibrarySettings,
       'visitorServiceEnabled': config.visitorServiceEnabled
     });
+
+    if (initialized) {
+      addToDataLayer(
+          {'plugin_name': plugin_name, 'plugin_version': plugin_version},
+          Expiry.forever);
+    }
+
+    return initialized;
   }
 
   // Tracks a [TealiumDispatch]
@@ -179,7 +189,7 @@ class Tealium {
           break;
         case EventListenerNames.consentExpired:
           Function callback = _listeners[EventListenerNames.consentExpired] =
-              _listeners[EventListenerNames.consentExpired] as Function;
+          _listeners[EventListenerNames.consentExpired] as Function;
           callback();
           break;
         case EventListenerNames.visitor:
@@ -188,7 +198,7 @@ class Tealium {
           eventDataMap as Map;
           eventDataMap.remove(EventListenerNames.name);
           Function callback = _listeners[EventListenerNames.visitor] =
-              _listeners[EventListenerNames.visitor] as Function;
+          _listeners[EventListenerNames.visitor] as Function;
           callback(eventDataMap);
           break;
         default:


### PR DESCRIPTION
- Moved `plugin_name` and `plugin_version` into `tealium.dart`