### PR TITLE
Fix gradle android - use maven-publish (fixes #23)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 version = "2.0.3"
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ rootProject.allprojects {
         google()
         jcenter()
         maven {
-            url "http://maven.tealiumiq.com/android/releases"
+            url "https://maven.tealiumiq.com/android/releases"
         }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/Tealium/tealium-flutter/issues/23 - by using `maven-publish` and https for the maven repo url