### PR TITLE
[MT-1949] Bump Android TagManagement Dispatcher to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full documentation](https://docs.tealium.com/platforms/flutter/install/)
 
+### 3.0.1 (Mar 2026)
+* Android: Updated TagManagement Dispatcher 1.3.0 → 1.3.1. WebView console messages are now always intercepted, so `I/chromium` logs no longer appear in logcat when `LogLevel.SILENT` is configured.
+
 ### 3.0.0 (Feb 2026)
 * Breaking change: `initialize` now returns `Future<void>` instead of `Future<bool>`. On failure a `PlatformException` is thrown instead of returning `false`.
 * Android & iOS: Fixed all MethodChannel methods to always return a result, preventing unresolved Futures. Critical fixes for `getFromDataLayer`, `gatherTrackData`, `addRemoteCommand`, and `setConsentExpiryListener`. All other methods now also properly resolve their Futures for consistency.

--- a/tealium/CHANGELOG.md
+++ b/tealium/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full documentation](https://docs.tealium.com/platforms/flutter/install/)
 
+### 3.0.1 (Mar 2026)
+* Android: Updated TagManagement Dispatcher 1.3.0 → 1.3.1. WebView console messages are now always intercepted, so `I/chromium` logs no longer appear in logcat when `LogLevel.SILENT` is configured.
+
 ### 3.0.0 (Feb 2026)
 * Breaking change: `initialize` now returns `Future<void>` instead of `Future<bool>`. On failure a `PlatformException` is thrown instead of returning `false`.
 * Android & iOS: Fixed all MethodChannel methods to always return a result, preventing unresolved Futures. Critical fixes for `getFromDataLayer`, `gatherTrackData`, `addRemoteCommand`, and `setConsentExpiryListener`. All other methods now also properly resolve their Futures for consistency.

--- a/tealium/android/build.gradle
+++ b/tealium/android/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     //Tealium
     implementation 'com.tealium:kotlin-core:1.9.2'
     implementation 'com.tealium:kotlin-collect-dispatcher:1.1.4'
-    implementation 'com.tealium:kotlin-tagmanagement-dispatcher:1.3.0'
+    implementation 'com.tealium:kotlin-tagmanagement-dispatcher:1.3.1'
     implementation 'com.tealium:kotlin-remotecommand-dispatcher:1.5.3'
     implementation 'com.tealium:kotlin-lifecycle:1.2.3'
     implementation 'com.tealium:kotlin-visitor-service:1.2.4'

--- a/tealium/android/build.gradle
+++ b/tealium/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.tealium'
-version '3.0.0'
+version '3.0.1'
 
 buildscript {
     ext.kotlin_version = rootProject.ext.has('kotlin_version') ? rootProject.ext.get('kotlin_version') : '1.8.0'

--- a/tealium/android/src/main/kotlin/com/tealium/Constants.kt
+++ b/tealium/android/src/main/kotlin/com/tealium/Constants.kt
@@ -58,6 +58,7 @@ const val KEY_LIFECYCLE_AUTO_TRACKING_ENABLED = "lifecycleAutotrackingEnabled"
 const val KEY_VISITOR_SERVICE_ENABLED = "visitorServiceEnabled"
 const val KEY_CUSTOM_VISITOR_ID = "customVisitorId"
 const val KEY_VISITOR_IDENTITY_KEY = "visitorIdentityKey"
+const val KEY_WEBVIEW_LOGGING_ENABLED = "webViewLoggingEnabled"
 
 class TealiumException(
     val code: String,

--- a/tealium/android/src/main/kotlin/com/tealium/Extensions.kt
+++ b/tealium/android/src/main/kotlin/com/tealium/Extensions.kt
@@ -21,6 +21,7 @@ import com.tealium.tagmanagementdispatcher.TagManagementDispatcher
 import com.tealium.tagmanagementdispatcher.overrideTagManagementUrl
 import com.tealium.tagmanagementdispatcher.remoteApiEnabled
 import com.tealium.tagmanagementdispatcher.sessionCountingEnabled
+import com.tealium.tagmanagementdispatcher.webViewLogsEnabled
 import com.tealium.visitorservice.VisitorProfile
 import com.tealium.visitorservice.VisitorService
 import org.json.JSONArray
@@ -167,7 +168,11 @@ fun toTealiumConfig(app: Application, configMap: Map<*, *>): TealiumConfig? {
         configMap[KEY_VISITOR_IDENTITY_KEY]?.let { key ->
             config.visitorIdentityKey = key.toString()
         }
-        
+
+        configMap[KEY_WEBVIEW_LOGGING_ENABLED]?.let {
+            webViewLogsEnabled = it.toString().toBoolean()
+        }
+
         // Disable RemoteAPI when RemoteCommands dispatcher is not present
         remoteApiEnabled = dispatchers?.contains(RemoteCommandDispatcher) ?: false
     }

--- a/tealium/example/ios/Podfile.lock
+++ b/tealium/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Flutter (1.0.0)
-  - tealium (3.0.0):
+  - tealium (3.0.1):
     - Flutter
     - tealium-swift/Collect (~> 2.18)
     - tealium-swift/Core (~> 2.18)
@@ -36,7 +36,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  tealium: 9032e4ba8cdb3407c93860ecde341b172f4b55e7
+  tealium: 33c92057745fb2cb712a6e409302d6218cfbcc67
   tealium-swift: 9c38e6687b24c9eed0f3bc221ea5d7717274af16
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce

--- a/tealium/example/lib/main.dart
+++ b/tealium/example/lib/main.dart
@@ -30,7 +30,7 @@ class _MyAppState extends State<MyApp> {
     'demo',
     TealiumEnvironment.dev,
     [Collectors.AppData, Collectors.Lifecycle],
-    [Dispatchers.RemoteCommands, Dispatchers.Collect],
+    [Dispatchers.RemoteCommands, Dispatchers.Collect, Dispatchers.TagManagement],
     loglevel: LogLevel.DEV,
     consentPolicy: ConsentPolicy.GDPR,
     useRemoteLibrarySettings: true,
@@ -38,6 +38,7 @@ class _MyAppState extends State<MyApp> {
     visitorServiceEnabled: true,
     consentExpiry: ConsentExpiry(5, TimeUnit.MINUTES),
     visitorIdentityKey: visitorIdentityKey,
+    webViewLoggingEnabled: false,
   );
 
   @override

--- a/tealium/example/pubspec.lock
+++ b/tealium/example/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.0.1"
   term_glyph:
     dependency: transitive
     description:

--- a/tealium/ios/tealium.podspec
+++ b/tealium/ios/tealium.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'tealium'
-  s.version = '3.0.0'
+  s.version = '3.0.1'
   s.summary = 'Tealium Flutter Plugin'
   s.description = <<-DESC
                   A Flutter plugin for the Tealium Swift and Kotlin SDKs.

--- a/tealium/lib/common.dart
+++ b/tealium/lib/common.dart
@@ -234,6 +234,7 @@ class TealiumConfig {
   bool? sessionCountingEnabled;
   List<RemoteCommand>? remoteCommands;
   String? visitorIdentityKey;
+  bool? webViewLoggingEnabled;
 
   TealiumConfig(this.account, this.profile, TealiumEnvironment environment,
       List<Collectors> collectors, List<Dispatchers> dispatchers,
@@ -259,7 +260,8 @@ class TealiumConfig {
       this.visitorServiceEnabled,
       this.sessionCountingEnabled,
       this.remoteCommands,
-      this.visitorIdentityKey}) {
+      this.visitorIdentityKey,
+      this.webViewLoggingEnabled}) {
     this.environment = environment.toString();
     this.collectors = collectors.map((item) => item.toString()).toList();
     this.dispatchers = dispatchers.map((item) => item.toString()).toList();

--- a/tealium/lib/tealium.dart
+++ b/tealium/lib/tealium.dart
@@ -62,7 +62,8 @@ class Tealium {
                 "path": e.path,
               })
           .toList(),
-      'visitorIdentityKey': config.visitorIdentityKey
+      'visitorIdentityKey': config.visitorIdentityKey,
+      'webViewLoggingEnabled': config.webViewLoggingEnabled
     });
 
     await addToDataLayer(

--- a/tealium/lib/tealium.dart
+++ b/tealium/lib/tealium.dart
@@ -6,7 +6,7 @@ import 'events/event_emitter.dart';
 
 class Tealium {
   static const String pluginName = 'Tealium-Flutter';
-  static const String pluginVersion = '3.0.0';
+  static const String pluginVersion = '3.0.1';
   static const MethodChannel _channel = MethodChannel('tealium');
   static EventEmitter emitter = EventEmitter();
   static final Map<String, Function> _remoteCommands = Map();

--- a/tealium/pubspec.yaml
+++ b/tealium/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tealium
 description: A Flutter plugin for using Tealium's Android and iOS libraries.
-version: 3.0.0
+version: 3.0.1
 homepage: https://tealium.com/
 documentation: https://docs.tealium.com/platforms/flutter/
 repository: https://github.com/Tealium/tealium-flutter


### PR DESCRIPTION
## Summary

- Bumps `kotlin-tagmanagement-dispatcher` from `1.3.0` to `1.3.1` on Android
- Fixes `I/chromium` WebView logs appearing in logcat even when `LogLevel.SILENT` is configured — version 1.3.1 always intercepts WebView console messages so they respect the configured log level
- Updates CHANGELOG with `3.0.1` release entry